### PR TITLE
Add support for BasicUser,BasicPass,FindString,CustomHeader

### DIFF
--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -91,6 +91,11 @@ func resourceStatusCakeTest() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"custom_header": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -112,6 +117,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		BasicUser:    d.Get("basic_user").(string),
 		BasicPass:    d.Get("basic_pass").(string),
 		FindString:   d.Get("contains_string").(string),
+		CustomHeader: d.Get("custom_header").(string),
 	}
 
 	log.Printf("[DEBUG] Creating new StatusCake Test: %s", d.Get("website_name").(string))
@@ -180,6 +186,7 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("basic_user", testResp.BasicUser)
 	d.Set("basic_pass", testResp.BasicPass)
 	d.Set("contains_string", testResp.FindString)
+	d.Set("custom_header", testResp.CustomHeader)
 
 	return nil
 }
@@ -233,6 +240,9 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("contains_string"); ok {
 		test.FindString = v.(string)
+	}
+	if v, ok := d.GetOk("custom_header"); ok {
+		test.CustomHeader = v.(string)
 	}
 
 	defaultStatusCodes := "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, " +

--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -76,6 +76,21 @@ func resourceStatusCakeTest() *schema.Resource {
 				Optional: true,
 				Default:  5,
 			},
+
+			"basic_user": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"basic_pass": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"contains_string": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -94,6 +109,9 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		Confirmation: d.Get("confirmations").(int),
 		Port:         d.Get("port").(int),
 		TriggerRate:  d.Get("trigger_rate").(int),
+		BasicUser:    d.Get("basic_user").(string),
+		BasicPass:    d.Get("basic_pass").(string),
+		FindString:   d.Get("contains_string").(string),
 	}
 
 	log.Printf("[DEBUG] Creating new StatusCake Test: %s", d.Get("website_name").(string))
@@ -159,6 +177,9 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("confirmations", testResp.Confirmation)
 	d.Set("port", testResp.Port)
 	d.Set("trigger_rate", testResp.TriggerRate)
+	d.Set("basic_user", testResp.BasicUser)
+	d.Set("basic_pass", testResp.BasicPass)
+	d.Set("contains_string", testResp.FindString)
 
 	return nil
 }
@@ -203,6 +224,15 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("trigger_rate"); ok {
 		test.TriggerRate = v.(int)
+	}
+	if v, ok := d.GetOk("basic_user"); ok {
+		test.BasicUser = v.(string)
+	}
+	if v, ok := d.GetOk("basic_pass"); ok {
+		test.BasicPass = v.(string)
+	}
+	if v, ok := d.GetOk("contains_string"); ok {
+		test.FindString = v.(string)
 	}
 
 	defaultStatusCodes := "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, " +

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -27,6 +27,7 @@ type detailResponse struct {
 	ContactID       int      `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
+	CustomHeader    string   `json:"CustomHeader"`
 	CheckRate       int      `json:"CheckRate"`
 	Timeout         int      `json:"Timeout"`
 	LogoImage       string   `json:"LogoImage"`
@@ -44,6 +45,7 @@ type detailResponse struct {
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
 	TriggerRate     int      `json:"TriggerRate,string"`
+	UseJar          bool     `json:"UseJar"`
 }
 
 func (d *detailResponse) test() *Test {
@@ -53,6 +55,7 @@ func (d *detailResponse) test() *Test {
 		Paused:        d.Paused,
 		WebsiteName:   d.WebsiteName,
 		WebsiteURL:    d.URI,
+		CustomHeader:  d.CustomHeader,
 		ContactID:     d.ContactID,
 		Status:        d.Status,
 		Uptime:        d.Uptime,
@@ -66,5 +69,6 @@ func (d *detailResponse) test() *Test {
 		DoNotFind:     d.DoNotFind,
 		Port:          d.Port,
 		TriggerRate:   d.TriggerRate,
+		UseJar:        d.UseJar,
 	}
 }

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -21,6 +21,9 @@ type Test struct {
 	// Website name. Tags are stripped out
 	WebsiteName string `json:"WebsiteName" querystring:"WebsiteName"`
 
+	// CustomHeader. A special header that will be sent along with the HTTP tests.
+	CustomHeader string `json:"CustomHeader" querystring:"CustomHeader"`
+
 	// Test location, either an IP (for TCP and Ping) or a fully qualified URL for other TestTypes
 	WebsiteURL string `json:"WebsiteURL" querystring:"WebsiteURL"`
 
@@ -91,6 +94,9 @@ type Test struct {
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
+
+	// Set to 1 to enable the Cookie Jar. Required for some redirects.
+	UseJar bool `json:"UseJar" querystring:"UseJar"`
 }
 
 // Validate checks if the Test is valid. If it's invalid, it returns a ValidationError with all invalid fields. It returns nil otherwise.
@@ -135,6 +141,10 @@ func (t *Test) Validate() error {
 
 	if t.TriggerRate < 0 || t.TriggerRate > 59 {
 		e["TriggerRate"] = "must be between 0 and 59"
+	}
+	var jsonVerifiable map[string]interface{}
+	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {
+		e["CustomHeader"] = "must be provided as json string"
 	}
 
 	if len(e) > 0 {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/",
 	"package": [
 		{
-			"checksumSHA1": "MV5JueYPwNkLZ+KNqmDcNDhsKi4=",
+			"checksumSHA1": "oxuGvDcln1djCm5rE9A6+k9xYcc=",
 			"path": "github.com/DreamItGetIT/statuscake",
-			"revision": "acc13ec021cd1e8a6ebb1d9035f513217f5c4562",
-			"revisionTime": "2017-04-10T11:34:45Z"
+			"revision": "f6b9cdfccf736eaca5fac0acb82ea8a3ebcac6f3",
+			"revisionTime": "2017-06-14T14:12:13Z"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",


### PR DESCRIPTION
This PR is to add support for some optional parameters in the StatusCake provider:
* BasicUser (string)
* BasicPass (string)
* FindString (string)
* CustomHeader (string) (escaped-JSON)

@grubernaut Please review