### PR TITLE
Add support for UserAgent, UseJar, PostRaw, FindString, FinalEndpoint, FollowRedirect, CustomHeader statuscake test options

### DIFF
--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -133,7 +133,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		TriggerRate:    d.Get("trigger_rate").(int),
 		CustomHeader:   d.Get("custom_header").(string),
 		UserAgent:      d.Get("user_agent").(string),
-		UseJar:         d.Get("use_jar").(bool),
+		UseJar:         d.Get("use_jar").(int),
 		PostRaw:        d.Get("post_raw").(string),
 		FindString:     d.Get("find_string").(string),
 		FinalEndpoint:  d.Get("final_endpoint").(string),
@@ -262,7 +262,7 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 		test.UserAgent = v.(string)
 	}
 	if v, ok := d.GetOk("use_jar"); ok {
-		test.UseJar = v.(bool)
+		test.UseJar = v.(int)
 	}
 	if v, ok := d.GetOk("post_raw"); ok {
 		test.PostRaw = v.(string)

--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -88,9 +88,9 @@ func resourceStatusCakeTest() *schema.Resource {
 			},
 
 			"use_jar": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  false,
+				Default:  0,
 			},
 
 			"post_raw": {

--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -76,6 +76,38 @@ func resourceStatusCakeTest() *schema.Resource {
 				Optional: true,
 				Default:  5,
 			},
+
+			"user_agent": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"use_jar": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"post_raw": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"find_string": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"final_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"follow_redirect": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -84,16 +116,22 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*statuscake.Client)
 
 	newTest := &statuscake.Test{
-		WebsiteName:  d.Get("website_name").(string),
-		WebsiteURL:   d.Get("website_url").(string),
-		CheckRate:    d.Get("check_rate").(int),
-		TestType:     d.Get("test_type").(string),
-		Paused:       d.Get("paused").(bool),
-		Timeout:      d.Get("timeout").(int),
-		ContactID:    d.Get("contact_id").(int),
-		Confirmation: d.Get("confirmations").(int),
-		Port:         d.Get("port").(int),
-		TriggerRate:  d.Get("trigger_rate").(int),
+		WebsiteName:    d.Get("website_name").(string),
+		WebsiteURL:     d.Get("website_url").(string),
+		CheckRate:      d.Get("check_rate").(int),
+		TestType:       d.Get("test_type").(string),
+		Paused:         d.Get("paused").(bool),
+		Timeout:        d.Get("timeout").(int),
+		ContactID:      d.Get("contact_id").(int),
+		Confirmation:   d.Get("confirmations").(int),
+		Port:           d.Get("port").(int),
+		TriggerRate:    d.Get("trigger_rate").(int),
+		UserAgent:      d.Get("user_agent").(string),
+		UseJar:         d.Get("use_jar").(bool),
+		PostRaw:        d.Get("post_raw").(string),
+		FindString:     d.Get("find_string").(string),
+		FinalEndpoint:  d.Get("final_endpoint").(string),
+		FollowRedirect: d.Get("follow_redirect").(bool),
 	}
 
 	log.Printf("[DEBUG] Creating new StatusCake Test: %s", d.Get("website_name").(string))
@@ -159,6 +197,12 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("confirmations", testResp.Confirmation)
 	d.Set("port", testResp.Port)
 	d.Set("trigger_rate", testResp.TriggerRate)
+	d.Set("user_agent", testResp.UserAgent)
+	d.Set("use_jar", testResp.UseJar)
+	d.Set("post_raw", testResp.PostRaw)
+	d.Set("find_string", testResp.FindString)
+	d.Set("final_endpoint", testResp.FinalEndpoint)
+	d.Set("follow_redirect", testResp.FollowRedirect)
 
 	return nil
 }
@@ -203,6 +247,24 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("trigger_rate"); ok {
 		test.TriggerRate = v.(int)
+	}
+	if v, ok := d.GetOk("user_agent"); ok {
+		test.UserAgent = v.(string)
+	}
+	if v, ok := d.GetOk("use_jar"); ok {
+		test.UseJar = v.(bool)
+	}
+	if v, ok := d.GetOk("post_raw"); ok {
+		test.PostRaw = v.(string)
+	}
+	if v, ok := d.GetOk("find_string"); ok {
+		test.FindString = v.(string)
+	}
+	if v, ok := d.GetOk("final_endpoint"); ok {
+		test.FinalEndpoint = v.(string)
+	}
+	if v, ok := d.GetOk("follow_redirect"); ok {
+		test.FollowRedirect = v.(bool)
 	}
 
 	defaultStatusCodes := "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, " +

--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -77,6 +77,11 @@ func resourceStatusCakeTest() *schema.Resource {
 				Default:  5,
 			},
 
+			"custom_header": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"user_agent": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -126,6 +131,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		Confirmation:   d.Get("confirmations").(int),
 		Port:           d.Get("port").(int),
 		TriggerRate:    d.Get("trigger_rate").(int),
+		CustomHeader:   d.Get("custom_header").(string),
 		UserAgent:      d.Get("user_agent").(string),
 		UseJar:         d.Get("use_jar").(bool),
 		PostRaw:        d.Get("post_raw").(string),
@@ -197,6 +203,7 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("confirmations", testResp.Confirmation)
 	d.Set("port", testResp.Port)
 	d.Set("trigger_rate", testResp.TriggerRate)
+	d.Set("custom_header", testResp.CustomHeader)
 	d.Set("user_agent", testResp.UserAgent)
 	d.Set("use_jar", testResp.UseJar)
 	d.Set("post_raw", testResp.PostRaw)
@@ -247,6 +254,9 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("trigger_rate"); ok {
 		test.TriggerRate = v.(int)
+	}
+	if v, ok := d.GetOk("custom_header"); ok {
+		test.CustomHeader = v.(string)
 	}
 	if v, ok := d.GetOk("user_agent"); ok {
 		test.UserAgent = v.(string)

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -1,5 +1,9 @@
 package statuscake
 
+import (
+	"strings"
+)
+
 type autheticationErrorResponse struct {
 	ErrNo int
 	Error string
@@ -27,6 +31,8 @@ type detailResponse struct {
 	ContactID       int      `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
+	CustomHeader    string   `json:"CustomHeader"`
+	UserAgent       string   `json:"UserAgent"`
 	CheckRate       int      `json:"CheckRate"`
 	Timeout         int      `json:"Timeout"`
 	LogoImage       string   `json:"LogoImage"`
@@ -44,27 +50,39 @@ type detailResponse struct {
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
 	TriggerRate     int      `json:"TriggerRate,string"`
+	UseJar          bool     `json:"UseJar"`
+	PostRaw         string   `json:"PostRaw"`
+	FinalEndpoint   string   `json:"FinalEndpoint"`
+	FollowRedirect  bool     `json:"FollowRedirect"`
+	StatusCodes     []string `json:"StatusCodes"`
 }
 
 func (d *detailResponse) test() *Test {
 	return &Test{
-		TestID:        d.TestID,
-		TestType:      d.TestType,
-		Paused:        d.Paused,
-		WebsiteName:   d.WebsiteName,
-		WebsiteURL:    d.URI,
-		ContactID:     d.ContactID,
-		Status:        d.Status,
-		Uptime:        d.Uptime,
-		CheckRate:     d.CheckRate,
-		Timeout:       d.Timeout,
-		LogoImage:     d.LogoImage,
-		Confirmation:  d.Confirmation,
-		WebsiteHost:   d.WebsiteHost,
-		NodeLocations: d.NodeLocations,
-		FindString:    d.FindString,
-		DoNotFind:     d.DoNotFind,
-		Port:          d.Port,
-		TriggerRate:   d.TriggerRate,
+		TestID:         d.TestID,
+		TestType:       d.TestType,
+		Paused:         d.Paused,
+		WebsiteName:    d.WebsiteName,
+		WebsiteURL:     d.URI,
+		CustomHeader:   d.CustomHeader,
+		UserAgent:      d.UserAgent,
+		ContactID:      d.ContactID,
+		Status:         d.Status,
+		Uptime:         d.Uptime,
+		CheckRate:      d.CheckRate,
+		Timeout:        d.Timeout,
+		LogoImage:      d.LogoImage,
+		Confirmation:   d.Confirmation,
+		WebsiteHost:    d.WebsiteHost,
+		NodeLocations:  d.NodeLocations,
+		FindString:     d.FindString,
+		DoNotFind:      d.DoNotFind,
+		Port:           d.Port,
+		TriggerRate:    d.TriggerRate,
+		UseJar:         d.UseJar,
+		PostRaw:        d.PostRaw,
+		FinalEndpoint:  d.FinalEndpoint,
+		FollowRedirect: d.FollowRedirect,
+		StatusCodes:    strings.Join(d.StatusCodes[:], ","),
 	}
 }

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -50,7 +50,7 @@ type detailResponse struct {
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
 	TriggerRate     int      `json:"TriggerRate,string"`
-	UseJar          bool     `json:"UseJar"`
+	UseJar          int      `json:"UseJar"`
 	PostRaw         string   `json:"PostRaw"`
 	FinalEndpoint   string   `json:"FinalEndpoint"`
 	FollowRedirect  bool     `json:"FollowRedirect"`

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -28,7 +28,7 @@ type detailResponse struct {
 	Paused          bool     `json:"Paused"`
 	WebsiteName     string   `json:"WebsiteName"`
 	URI             string   `json:"URI"`
-	ContactID       int      `json:"ContactID"`
+	ContactID       string   `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
 	CustomHeader    string   `json:"CustomHeader"`

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -21,6 +21,12 @@ type Test struct {
 	// Website name. Tags are stripped out
 	WebsiteName string `json:"WebsiteName" querystring:"WebsiteName"`
 
+	// CustomHeader. A special header that will be sent along with the HTTP tests.
+	CustomHeader string `json:"CustomHeader" querystring:"CustomHeader"`
+
+	// Use to populate the test with a custom user agent
+	UserAgent string `json:"UserAgent" queryString:"UserAgent"`
+
 	// Test location, either an IP (for TCP and Ping) or a fully qualified URL for other TestTypes
 	WebsiteURL string `json:"WebsiteURL" querystring:"WebsiteURL"`
 
@@ -91,6 +97,18 @@ type Test struct {
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
+
+	// Set to 1 to enable the Cookie Jar. Required for some redirects.
+	UseJar bool `json:"UseJar" querystring:"UseJar"`
+
+	// Raw POST data seperated by an ampersand
+	PostRaw string `json:"PostRaw" querystring:"PostRaw"`
+
+	// Use to specify the expected Final URL in the testing process
+	FinalEndpoint string `json:"FinalEndpoint" querystring:"FinalEndpoint"`
+
+	// Use to specify whether redirects should be followed
+	FollowRedirect bool `json:"FollowRedirect" querystring:"FollowRedirect"`
 }
 
 // Validate checks if the Test is valid. If it's invalid, it returns a ValidationError with all invalid fields. It returns nil otherwise.
@@ -135,6 +153,19 @@ func (t *Test) Validate() error {
 
 	if t.TriggerRate < 0 || t.TriggerRate > 59 {
 		e["TriggerRate"] = "must be between 0 and 59"
+	}
+
+	if t.PostRaw != "" && t.TestType != "HTTP" {
+		e["PostRaw"] = "must be HTTP to submit a POST request"
+	}
+
+	if t.FinalEndpoint != "" && t.TestType != "HTTP" {
+		e["FinalEndpoint"] = "must be a Valid URL"
+	}
+
+	var jsonVerifiable map[string]interface{}
+	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {
+		e["CustomHeader"] = "must be provided as json string"
 	}
 
 	if len(e) > 0 {

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -99,7 +99,7 @@ type Test struct {
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
 
 	// Set to 1 to enable the Cookie Jar. Required for some redirects.
-	UseJar bool `json:"UseJar" querystring:"UseJar"`
+	UseJar int `json:"UseJar" querystring:"UseJar"`
 
 	// Raw POST data seperated by an ampersand
 	PostRaw string `json:"PostRaw" querystring:"PostRaw"`

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -34,7 +34,7 @@ type Test struct {
 	Port int `json:"Port" querystring:"Port"`
 
 	// Contact group ID - will return int of contact group used else 0
-	ContactID int `json:"ContactID" querystring:"ContactGroup"`
+	ContactID string `json:"ContactID" querystring:"ContactGroup"`
 
 	// Current status at last test
 	Status string `json:"Status"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"checksumSHA1": "MV5JueYPwNkLZ+KNqmDcNDhsKi4=",
+			"checksumSHA1": "UDL7d1YHLnGWbuPZknKU+1ABNSM=",
 			"path": "github.com/DreamItGetIT/statuscake",
-			"revision": "acc13ec021cd1e8a6ebb1d9035f513217f5c4562",
-			"revisionTime": "2017-04-10T11:34:45Z"
+			"revision": "a44c945f75f458be83864438f4af9dfb82583ad6",
+			"revisionTime": "2017-11-09T16:06:10Z"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"checksumSHA1": "UDL7d1YHLnGWbuPZknKU+1ABNSM=",
+			"checksumSHA1": "xjfJ6T+mQFmC9oMR+UKdGtbs/p4=",
 			"path": "github.com/DreamItGetIT/statuscake",
-			"revision": "a44c945f75f458be83864438f4af9dfb82583ad6",
-			"revisionTime": "2017-11-09T16:06:10Z"
+			"revision": "2081e16dbe691bccf20b1901897d8f8245beefcd",
+			"revisionTime": "2018-01-09T18:02:45Z"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",


### PR DESCRIPTION
This PR is to add support for some optional parameters in the StatusCake provider:

- `UserAgent (string)`
- `UseJar (bool)`
- `PostRaw (string)`
- `FindString (string)`
- `FinalEndpoint (string)`
- `FollowRedirect (bool)`
- `CustomHeader (string)`

@radeksimko || @grubernaut Please review.

Thanks!