### PR TITLE
Parse contact_id as a string, enabling comma separated values.

### DIFF
--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -34,7 +34,7 @@ func resourceStatusCakeTest() *schema.Resource {
 			},
 
 			"contact_id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 
@@ -90,7 +90,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		TestType:     d.Get("test_type").(string),
 		Paused:       d.Get("paused").(bool),
 		Timeout:      d.Get("timeout").(int),
-		ContactID:    d.Get("contact_id").(int),
+		ContactID:    d.Get("contact_id").(string),
 		Confirmation: d.Get("confirmations").(int),
 		Port:         d.Get("port").(int),
 		TriggerRate:  d.Get("trigger_rate").(int),
@@ -181,7 +181,7 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 		test.CheckRate = v.(int)
 	}
 	if v, ok := d.GetOk("contact_id"); ok {
-		test.ContactID = v.(int)
+		test.ContactID = v.(string)
 	}
 	if v, ok := d.GetOk("test_type"); ok {
 		test.TestType = v.(string)
@@ -191,9 +191,6 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("timeout"); ok {
 		test.Timeout = v.(int)
-	}
-	if v, ok := d.GetOk("contact_id"); ok {
-		test.ContactID = v.(int)
 	}
 	if v, ok := d.GetOk("confirmations"); ok {
 		test.Confirmation = v.(int)

--- a/statuscake/resource_statuscaketest_test.go
+++ b/statuscake/resource_statuscaketest_test.go
@@ -136,8 +136,6 @@ func testAccTestCheckAttributes(rn string, test *statuscake.Test) resource.TestC
 				err = check(key, value, strconv.FormatBool(test.Paused))
 			case "timeout":
 				err = check(key, value, strconv.Itoa(test.Timeout))
-			case "contact_id":
-				err = check(key, value, strconv.Itoa(test.ContactID))
 			case "confirmations":
 				err = check(key, value, strconv.Itoa(test.Confirmation))
 			case "trigger_rate":
@@ -171,7 +169,7 @@ resource "statuscake_test" "google" {
 	test_type = "HTTP"
 	check_rate = 300
 	timeout = 10
-	contact_id = 43402
+	contact_id = "43402"
 	confirmations = 1
 	trigger_rate = 10
 }
@@ -195,7 +193,7 @@ resource "statuscake_test" "google" {
 	test_type = "TCP"
 	check_rate = 300
 	timeout = 10
-	contact_id = 43402
+	contact_id = "43402"
 	confirmations = 1
 	port = 80
 }

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -1,5 +1,9 @@
 package statuscake
 
+import (
+	"strings"
+)
+
 type autheticationErrorResponse struct {
 	ErrNo int
 	Error string
@@ -24,9 +28,11 @@ type detailResponse struct {
 	Paused          bool     `json:"Paused"`
 	WebsiteName     string   `json:"WebsiteName"`
 	URI             string   `json:"URI"`
-	ContactID       int      `json:"ContactID"`
+	ContactID       string   `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
+	CustomHeader    string   `json:"CustomHeader"`
+	UserAgent       string   `json:"UserAgent"`
 	CheckRate       int      `json:"CheckRate"`
 	Timeout         int      `json:"Timeout"`
 	LogoImage       string   `json:"LogoImage"`
@@ -44,27 +50,39 @@ type detailResponse struct {
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
 	TriggerRate     int      `json:"TriggerRate,string"`
+	UseJar          bool     `json:"UseJar"`
+	PostRaw         string   `json:"PostRaw"`
+	FinalEndpoint   string   `json:"FinalEndpoint"`
+	FollowRedirect  bool     `json:"FollowRedirect"`
+	StatusCodes     []string `json:"StatusCodes"`
 }
 
 func (d *detailResponse) test() *Test {
 	return &Test{
-		TestID:        d.TestID,
-		TestType:      d.TestType,
-		Paused:        d.Paused,
-		WebsiteName:   d.WebsiteName,
-		WebsiteURL:    d.URI,
-		ContactID:     d.ContactID,
-		Status:        d.Status,
-		Uptime:        d.Uptime,
-		CheckRate:     d.CheckRate,
-		Timeout:       d.Timeout,
-		LogoImage:     d.LogoImage,
-		Confirmation:  d.Confirmation,
-		WebsiteHost:   d.WebsiteHost,
-		NodeLocations: d.NodeLocations,
-		FindString:    d.FindString,
-		DoNotFind:     d.DoNotFind,
-		Port:          d.Port,
-		TriggerRate:   d.TriggerRate,
+		TestID:         d.TestID,
+		TestType:       d.TestType,
+		Paused:         d.Paused,
+		WebsiteName:    d.WebsiteName,
+		WebsiteURL:     d.URI,
+		CustomHeader:   d.CustomHeader,
+		UserAgent:      d.UserAgent,
+		ContactID:      d.ContactID,
+		Status:         d.Status,
+		Uptime:         d.Uptime,
+		CheckRate:      d.CheckRate,
+		Timeout:        d.Timeout,
+		LogoImage:      d.LogoImage,
+		Confirmation:   d.Confirmation,
+		WebsiteHost:    d.WebsiteHost,
+		NodeLocations:  d.NodeLocations,
+		FindString:     d.FindString,
+		DoNotFind:      d.DoNotFind,
+		Port:           d.Port,
+		TriggerRate:    d.TriggerRate,
+		UseJar:         d.UseJar,
+		PostRaw:        d.PostRaw,
+		FinalEndpoint:  d.FinalEndpoint,
+		FollowRedirect: d.FollowRedirect,
+		StatusCodes:    strings.Join(d.StatusCodes[:], ","),
 	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"checksumSHA1": "MV5JueYPwNkLZ+KNqmDcNDhsKi4=",
+			"checksumSHA1": "xakirOTtnTfhVVk7CBlWRgQ8d30=",
 			"path": "github.com/DreamItGetIT/statuscake",
-			"revision": "acc13ec021cd1e8a6ebb1d9035f513217f5c4562",
-			"revisionTime": "2017-04-10T11:34:45Z"
+			"revision": "6d9f5a02994f614eb659df543a141c2b41944393",
+			"revisionTime": "2018-01-09T17:56:33Z"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -34,6 +34,6 @@ resource "statuscake_test" "google" {
   website_url  = "www.google.com"
   test_type    = "HTTP"
   check_rate   = 300
-  contact_id   = 12345
+  contact_id   = "12345,54321"
 }
 ```


### PR DESCRIPTION
Closes #8 