### PR TITLE
Adding the status code options.

### DIFF
--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -76,6 +76,52 @@ func resourceStatusCakeTest() *schema.Resource {
 				Optional: true,
 				Default:  5,
 			},
+
+			"custom_header": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"user_agent": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"use_jar": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"post_raw": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"find_string": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"final_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"follow_redirect": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"status_codes": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default: "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, " +
+					"408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, " +
+					"504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, " +
+					"598, 599",
+			},
 		},
 	}
 }
@@ -159,6 +205,14 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("confirmations", testResp.Confirmation)
 	d.Set("port", testResp.Port)
 	d.Set("trigger_rate", testResp.TriggerRate)
+	d.Set("custom_header", testResp.CustomHeader)
+	d.Set("user_agent", testResp.UserAgent)
+	d.Set("use_jar", testResp.UseJar)
+	d.Set("post_raw", testResp.PostRaw)
+	d.Set("find_string", testResp.FindString)
+	d.Set("final_endpoint", testResp.FinalEndpoint)
+	d.Set("follow_redirect", testResp.FollowRedirect)
+	d.Set("status_codes", testResp.StatusCodes)
 
 	return nil
 }
@@ -204,13 +258,30 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	if v, ok := d.GetOk("trigger_rate"); ok {
 		test.TriggerRate = v.(int)
 	}
-
-	defaultStatusCodes := "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, " +
-		"408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, " +
-		"504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, " +
-		"598, 599"
-
-	test.StatusCodes = defaultStatusCodes
+	if v, ok := d.GetOk("custom_header"); ok {
+		test.CustomHeader = v.(string)
+	}
+	if v, ok := d.GetOk("user_agent"); ok {
+		test.UserAgent = v.(string)
+	}
+	if v, ok := d.GetOk("use_jar"); ok {
+		test.UseJar = v.(bool)
+	}
+	if v, ok := d.GetOk("post_raw"); ok {
+		test.PostRaw = v.(string)
+	}
+	if v, ok := d.GetOk("find_string"); ok {
+		test.FindString = v.(string)
+	}
+	if v, ok := d.GetOk("final_endpoint"); ok {
+		test.FinalEndpoint = v.(string)
+	}
+	if v, ok := d.GetOk("follow_redirect"); ok {
+		test.FollowRedirect = v.(bool)
+	}
+	if v, ok := d.GetOk("status_codes"); ok {
+		test.StatusCodes = v.(string)
+	}
 
 	return test
 }

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -1,5 +1,9 @@
 package statuscake
 
+import (
+	"strings"
+)
+
 type autheticationErrorResponse struct {
 	ErrNo int
 	Error string
@@ -27,6 +31,8 @@ type detailResponse struct {
 	ContactID       int      `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
+	CustomHeader    string   `json:"CustomHeader"`
+	UserAgent       string   `json:"UserAgent"`
 	CheckRate       int      `json:"CheckRate"`
 	Timeout         int      `json:"Timeout"`
 	LogoImage       string   `json:"LogoImage"`
@@ -44,27 +50,39 @@ type detailResponse struct {
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
 	TriggerRate     int      `json:"TriggerRate,string"`
+	UseJar          bool     `json:"UseJar"`
+	PostRaw         string   `json:"PostRaw"`
+	FinalEndpoint   string   `json:"FinalEndpoint"`
+	FollowRedirect  bool     `json:"FollowRedirect"`
+	StatusCodes     []string `json:"StatusCodes"`
 }
 
 func (d *detailResponse) test() *Test {
 	return &Test{
-		TestID:        d.TestID,
-		TestType:      d.TestType,
-		Paused:        d.Paused,
-		WebsiteName:   d.WebsiteName,
-		WebsiteURL:    d.URI,
-		ContactID:     d.ContactID,
-		Status:        d.Status,
-		Uptime:        d.Uptime,
-		CheckRate:     d.CheckRate,
-		Timeout:       d.Timeout,
-		LogoImage:     d.LogoImage,
-		Confirmation:  d.Confirmation,
-		WebsiteHost:   d.WebsiteHost,
-		NodeLocations: d.NodeLocations,
-		FindString:    d.FindString,
-		DoNotFind:     d.DoNotFind,
-		Port:          d.Port,
-		TriggerRate:   d.TriggerRate,
+		TestID:         d.TestID,
+		TestType:       d.TestType,
+		Paused:         d.Paused,
+		WebsiteName:    d.WebsiteName,
+		WebsiteURL:     d.URI,
+		CustomHeader:   d.CustomHeader,
+		UserAgent:      d.UserAgent,
+		ContactID:      d.ContactID,
+		Status:         d.Status,
+		Uptime:         d.Uptime,
+		CheckRate:      d.CheckRate,
+		Timeout:        d.Timeout,
+		LogoImage:      d.LogoImage,
+		Confirmation:   d.Confirmation,
+		WebsiteHost:    d.WebsiteHost,
+		NodeLocations:  d.NodeLocations,
+		FindString:     d.FindString,
+		DoNotFind:      d.DoNotFind,
+		Port:           d.Port,
+		TriggerRate:    d.TriggerRate,
+		UseJar:         d.UseJar,
+		PostRaw:        d.PostRaw,
+		FinalEndpoint:  d.FinalEndpoint,
+		FollowRedirect: d.FollowRedirect,
+		StatusCodes:    strings.Join(d.StatusCodes[:], ","),
 	}
 }

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -21,6 +21,12 @@ type Test struct {
 	// Website name. Tags are stripped out
 	WebsiteName string `json:"WebsiteName" querystring:"WebsiteName"`
 
+	// CustomHeader. A special header that will be sent along with the HTTP tests.
+	CustomHeader string `json:"CustomHeader" querystring:"CustomHeader"`
+
+	// Use to populate the test with a custom user agent
+	UserAgent string `json:"UserAgent" queryString:"UserAgent"`
+
 	// Test location, either an IP (for TCP and Ping) or a fully qualified URL for other TestTypes
 	WebsiteURL string `json:"WebsiteURL" querystring:"WebsiteURL"`
 
@@ -91,6 +97,18 @@ type Test struct {
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
+
+	// Set to 1 to enable the Cookie Jar. Required for some redirects.
+	UseJar bool `json:"UseJar" querystring:"UseJar"`
+
+	// Raw POST data seperated by an ampersand
+	PostRaw string `json:"PostRaw" querystring:"PostRaw"`
+
+	// Use to specify the expected Final URL in the testing process
+	FinalEndpoint string `json:"FinalEndpoint" querystring:"FinalEndpoint"`
+
+	// Use to specify whether redirects should be followed
+	FollowRedirect bool `json:"FollowRedirect" querystring:"FollowRedirect"`
 }
 
 // Validate checks if the Test is valid. If it's invalid, it returns a ValidationError with all invalid fields. It returns nil otherwise.
@@ -135,6 +153,19 @@ func (t *Test) Validate() error {
 
 	if t.TriggerRate < 0 || t.TriggerRate > 59 {
 		e["TriggerRate"] = "must be between 0 and 59"
+	}
+
+	if t.PostRaw != "" && t.TestType != "HTTP" {
+		e["PostRaw"] = "must be HTTP to submit a POST request"
+	}
+
+	if t.FinalEndpoint != "" && t.TestType != "HTTP" {
+		e["FinalEndpoint"] = "must be a Valid URL"
+	}
+
+	var jsonVerifiable map[string]interface{}
+	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {
+		e["CustomHeader"] = "must be provided as json string"
 	}
 
 	if len(e) > 0 {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"checksumSHA1": "MV5JueYPwNkLZ+KNqmDcNDhsKi4=",
+			"checksumSHA1": "UDL7d1YHLnGWbuPZknKU+1ABNSM=",
 			"path": "github.com/DreamItGetIT/statuscake",
-			"revision": "acc13ec021cd1e8a6ebb1d9035f513217f5c4562",
-			"revisionTime": "2017-04-10T11:34:45Z"
+			"revision": "a44c945f75f458be83864438f4af9dfb82583ad6",
+			"revisionTime": "2017-11-09T16:06:10Z"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",

--- a/website/docs/r/test.html.markdown
+++ b/website/docs/r/test.html.markdown
@@ -36,6 +36,14 @@ The following arguments are supported:
 * `confirmations` - (Optional) The number of confirmation servers to use in order to detect downtime. Defaults to 0.
 * `port` - (Optional) The port to use when specifying a TCP test.
 * `trigger_rate` - (Optional) The number of minutes to wait before sending an alert. Default is `5`.
+* `custom_header` - (Optional) Custom HTTP header, must be supplied as JSON
+* `user_agent` - (Optional) Test with a custom user agent set.
+* `use_jar` - (Optional) Set to true to enable the Cookie Jar. Required for some redirects. Default is false.
+* `post_raw` - (Optional) Use to populate the RAW POST data field on the test.
+* `find_string` - (Optional) A string that should either be found or not found.
+* `final_endpoint` - (Optional) Use to specify the expected Final URL in the testing process
+* `follow_redirect` - (Optional) Use to specify whether redirects should be followed, set to true to enable. Default is false.
+* `status_codes` - (Optional) Comma Seperated List of StatusCodes to Trigger Error on. Defaults are "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
 
 
 ## Attributes Reference


### PR DESCRIPTION
Updating the statuscake go support from upstream.

Adding all the extra type support from the #7 PR by jmherbst.

Finally adding in status_codes support to define the status codes that
will trigger an alert and ensuring the defaults provided by StatusCake
will be set.

This fixes #5 