### PR TITLE
Update acceptable test_type values

### DIFF
--- a/website/docs/r/test.html.markdown
+++ b/website/docs/r/test.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `website_url` - (Required) The URL of the website to be monitored
 * `check_rate` - (Optional) Test check rate in seconds. Defaults to 300
 * `contact_id` - (Optional) The id of the contact group to be add to the test.  Each test can have only one.
-* `test_type` - (Required) The type of Test. Either HTTP or TCP
+* `test_type` - (Required) The type of Test. Either HTTP, TCP, PING, or DNS
 * `paused` - (Optional) Whether or not the test is paused. Defaults to false.
 * `timeout` - (Optional) The timeout of the test in seconds.
 * `confirmations` - (Optional) The number of confirmation servers to use in order to detect downtime. Defaults to 0.


### PR DESCRIPTION
Haven't confirmed, but at least according to error messages "Valid Types are: HTTP, TCP, PING, DNS"