### PR TITLE
Support limiting NodeLocations for tests

### DIFF
--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -76,6 +76,12 @@ func resourceStatusCakeTest() *schema.Resource {
 				Optional: true,
 				Default:  5,
 			},
+
+			"node_locations": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 		},
 	}
 }
@@ -84,16 +90,17 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*statuscake.Client)
 
 	newTest := &statuscake.Test{
-		WebsiteName:  d.Get("website_name").(string),
-		WebsiteURL:   d.Get("website_url").(string),
-		CheckRate:    d.Get("check_rate").(int),
-		TestType:     d.Get("test_type").(string),
-		Paused:       d.Get("paused").(bool),
-		Timeout:      d.Get("timeout").(int),
-		ContactID:    d.Get("contact_id").(int),
-		Confirmation: d.Get("confirmations").(int),
-		Port:         d.Get("port").(int),
-		TriggerRate:  d.Get("trigger_rate").(int),
+		WebsiteName:   d.Get("website_name").(string),
+		WebsiteURL:    d.Get("website_url").(string),
+		CheckRate:     d.Get("check_rate").(int),
+		TestType:      d.Get("test_type").(string),
+		Paused:        d.Get("paused").(bool),
+		Timeout:       d.Get("timeout").(int),
+		ContactID:     d.Get("contact_id").(int),
+		Confirmation:  d.Get("confirmations").(int),
+		Port:          d.Get("port").(int),
+		TriggerRate:   d.Get("trigger_rate").(int),
+		NodeLocations: d.Get("node_locations").(string),
 	}
 
 	log.Printf("[DEBUG] Creating new StatusCake Test: %s", d.Get("website_name").(string))
@@ -159,6 +166,7 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("confirmations", testResp.Confirmation)
 	d.Set("port", testResp.Port)
 	d.Set("trigger_rate", testResp.TriggerRate)
+	d.Set("node_locations", testResp.NodeLocations)
 
 	return nil
 }
@@ -203,6 +211,9 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("trigger_rate"); ok {
 		test.TriggerRate = v.(int)
+	}
+	if v, ok := d.GetOk("node_locations"); ok {
+		test.NodeLocations = v.(string)
 	}
 
 	defaultStatusCodes := "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, " +

--- a/statuscake/resource_statuscaketest_test.go
+++ b/statuscake/resource_statuscaketest_test.go
@@ -74,6 +74,7 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("statuscake_test.google", "contact_id", "0"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "confirmations", "0"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "trigger_rate", "20"),
+					resource.TestCheckResourceAttr("statuscake_test.google", "node_locations", "HRSM1, thndr2"),
 				),
 			},
 		},
@@ -142,6 +143,8 @@ func testAccTestCheckAttributes(rn string, test *statuscake.Test) resource.TestC
 				err = check(key, value, strconv.Itoa(test.Confirmation))
 			case "trigger_rate":
 				err = check(key, value, strconv.Itoa(test.TriggerRate))
+			case "node_locations":
+				err = check(key, value, test.NodeLocations)
 			}
 
 			if err != nil {
@@ -174,6 +177,7 @@ resource "statuscake_test" "google" {
 	contact_id = 43402
 	confirmations = 1
 	trigger_rate = 10
+	node_locations = "sil1, flo2"
 }
 `
 
@@ -185,6 +189,7 @@ resource "statuscake_test" "google" {
 	check_rate = 500
 	paused = true
 	trigger_rate = 20
+	node_locations = "HRSM1, thndr2"
 }
 `
 
@@ -198,5 +203,6 @@ resource "statuscake_test" "google" {
 	contact_id = 43402
 	confirmations = 1
 	port = 80
+	node_locations = "sil1,flo2"
 }
 `

--- a/vendor/github.com/DreamItGetIT/statuscake/errors.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/errors.go
@@ -34,11 +34,14 @@ func (e ValidationError) Error() string {
 }
 
 type updateError struct {
-	Issues interface{}
+	Issues  interface{}
+	Message string
 }
 
 func (e *updateError) Error() string {
 	var messages []string
+
+	messages = append(messages, e.Message)
 
 	if issues, ok := e.Issues.(map[string]interface{}); ok {
 		for k, v := range issues {
@@ -50,6 +53,9 @@ func (e *updateError) Error() string {
 			m := fmt.Sprint(v)
 			messages = append(messages, m)
 		}
+	} else if issue, ok := e.Issues.(interface{}); ok {
+		m := fmt.Sprint(issue)
+		messages = append(messages, m)
 	}
 
 	return strings.Join(messages, ", ")

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -1,5 +1,9 @@
 package statuscake
 
+import (
+	"strings"
+)
+
 type autheticationErrorResponse struct {
 	ErrNo int
 	Error string
@@ -27,6 +31,8 @@ type detailResponse struct {
 	ContactID       int      `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
+	CustomHeader    string   `json:"CustomHeader"`
+	UserAgent       string   `json:"UserAgent"`
 	CheckRate       int      `json:"CheckRate"`
 	Timeout         int      `json:"Timeout"`
 	LogoImage       string   `json:"LogoImage"`
@@ -44,27 +50,39 @@ type detailResponse struct {
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
 	TriggerRate     int      `json:"TriggerRate,string"`
+	UseJar          int      `json:"UseJar"`
+	PostRaw         string   `json:"PostRaw"`
+	FinalEndpoint   string   `json:"FinalEndpoint"`
+	FollowRedirect  bool     `json:"FollowRedirect"`
+	StatusCodes     []string `json:"StatusCodes"`
 }
 
 func (d *detailResponse) test() *Test {
 	return &Test{
-		TestID:        d.TestID,
-		TestType:      d.TestType,
-		Paused:        d.Paused,
-		WebsiteName:   d.WebsiteName,
-		WebsiteURL:    d.URI,
-		ContactID:     d.ContactID,
-		Status:        d.Status,
-		Uptime:        d.Uptime,
-		CheckRate:     d.CheckRate,
-		Timeout:       d.Timeout,
-		LogoImage:     d.LogoImage,
-		Confirmation:  d.Confirmation,
-		WebsiteHost:   d.WebsiteHost,
-		NodeLocations: d.NodeLocations,
-		FindString:    d.FindString,
-		DoNotFind:     d.DoNotFind,
-		Port:          d.Port,
-		TriggerRate:   d.TriggerRate,
+		TestID:         d.TestID,
+		TestType:       d.TestType,
+		Paused:         d.Paused,
+		WebsiteName:    d.WebsiteName,
+		WebsiteURL:     d.URI,
+		CustomHeader:   d.CustomHeader,
+		UserAgent:      d.UserAgent,
+		ContactID:      d.ContactID,
+		Status:         d.Status,
+		Uptime:         d.Uptime,
+		CheckRate:      d.CheckRate,
+		Timeout:        d.Timeout,
+		LogoImage:      d.LogoImage,
+		Confirmation:   d.Confirmation,
+		WebsiteHost:    d.WebsiteHost,
+		NodeLocations:  strings.Join(d.NodeLocations, ","),
+		FindString:     d.FindString,
+		DoNotFind:      d.DoNotFind,
+		Port:           d.Port,
+		TriggerRate:    d.TriggerRate,
+		UseJar:         d.UseJar,
+		PostRaw:        d.PostRaw,
+		FinalEndpoint:  d.FinalEndpoint,
+		FollowRedirect: d.FollowRedirect,
+		StatusCodes:    strings.Join(d.StatusCodes[:], ","),
 	}
 }

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"regexp"
 )
 
 const queryStringTag = "querystring"
@@ -20,6 +21,12 @@ type Test struct {
 
 	// Website name. Tags are stripped out
 	WebsiteName string `json:"WebsiteName" querystring:"WebsiteName"`
+
+	// CustomHeader. A special header that will be sent along with the HTTP tests.
+	CustomHeader string `json:"CustomHeader" querystring:"CustomHeader"`
+
+	// Use to populate the test with a custom user agent
+	UserAgent string `json:"UserAgent" queryString:"UserAgent"`
 
 	// Test location, either an IP (for TCP and Ping) or a fully qualified URL for other TestTypes
 	WebsiteURL string `json:"WebsiteURL" querystring:"WebsiteURL"`
@@ -37,7 +44,7 @@ type Test struct {
 	Uptime float64 `json:"Uptime"`
 
 	// Any test locations seperated by a comma (using the Node Location IDs)
-	NodeLocations []string `json:"NodeLocations" querystring:"NodeLocations"`
+	NodeLocations string `json:"NodeLocations" querystring:"NodeLocations"`
 
 	// Timeout in an int form representing seconds.
 	Timeout int `json:"Timeout" querystring:"Timeout"`
@@ -91,6 +98,18 @@ type Test struct {
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
+
+	// Set to 1 to enable the Cookie Jar. Required for some redirects.
+	UseJar int `json:"UseJar" querystring:"UseJar"`
+
+	// Raw POST data seperated by an ampersand
+	PostRaw string `json:"PostRaw" querystring:"PostRaw"`
+
+	// Use to specify the expected Final URL in the testing process
+	FinalEndpoint string `json:"FinalEndpoint" querystring:"FinalEndpoint"`
+
+	// Use to specify whether redirects should be followed
+	FollowRedirect bool `json:"FollowRedirect" querystring:"FollowRedirect"`
 }
 
 // Validate checks if the Test is valid. If it's invalid, it returns a ValidationError with all invalid fields. It returns nil otherwise.
@@ -135,6 +154,30 @@ func (t *Test) Validate() error {
 
 	if t.TriggerRate < 0 || t.TriggerRate > 59 {
 		e["TriggerRate"] = "must be between 0 and 59"
+	}
+
+	if t.PostRaw != "" && t.TestType != "HTTP" {
+		e["PostRaw"] = "must be HTTP to submit a POST request"
+	}
+
+	if t.FinalEndpoint != "" && t.TestType != "HTTP" {
+		e["FinalEndpoint"] = "must be a Valid URL"
+	}
+
+	var jsonVerifiable map[string]interface{}
+	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {
+		e["CustomHeader"] = "must be provided as json string"
+	}
+
+	match, err := regexp.MatchString("^([0-9A-Za-z]*[,][[:space:]]*)*[0-9A-Za-z]+$", t.NodeLocations)
+
+	if err != nil {
+		fmt.Printf("There is a problem with regexp. This is an upstream problem.\n")
+		return nil
+	}
+
+	if match != true {
+		e["NodeLocations"] = "must be test locastion IDs separated by a comma"
 	}
 
 	if len(e) > 0 {
@@ -252,7 +295,7 @@ func (tt *tests) Update(t *Test) (*Test, error) {
 	}
 
 	if !ur.Success {
-		return nil, &updateError{Issues: ur.Issues}
+		return nil, &updateError{Issues: ur.Issues, Message: ur.Message}
 	}
 
 	t2 := *t

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"checksumSHA1": "MV5JueYPwNkLZ+KNqmDcNDhsKi4=",
+			"checksumSHA1": "NbEZVMOLTh7Tp/X9Y+PVzyB0508=",
 			"path": "github.com/DreamItGetIT/statuscake",
-			"revision": "acc13ec021cd1e8a6ebb1d9035f513217f5c4562",
-			"revisionTime": "2017-04-10T11:34:45Z"
+			"revision": "23cc9fdfa338fdd2569319a79a31e43277a31cda",
+			"revisionTime": "2018-07-12T09:44:06Z"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",


### PR DESCRIPTION
Current Terraform cannot create statusCake Tests with test locations. Updating upstream Terraform support to create/update Statuscake tests with NodeLocations.

Adding node_locations to include `NodeLocations` option to Statuscake API.

StatusCake API receives `string` type input to create or update tests but it has a  `[]string` type  NodeLocations response. A `[]string` to `string` convention is added to solve this issue. 

Need validation with `make testacc`.

@grubernaut || @radeksimko Please review. Thanks!