### PR TITLE
WIP - Add test contact group support

### DIFF
--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -94,6 +94,7 @@ func resourceStatusCakeTest() *schema.Resource {
 				Optional: true,
 				Default:  5,
 			},
+
 			"custom_header": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -178,8 +179,10 @@ func resourceStatusCakeTest() *schema.Resource {
 			},
 
 			"test_tags": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				Set:      schema.HashString,
 			},
 
 			"status_codes": {
@@ -240,7 +243,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		FindString:     d.Get("find_string").(string),
 		DoNotFind:      d.Get("do_not_find").(bool),
 		RealBrowser:    d.Get("real_browser").(int),
-		TestTags:       d.Get("test_tags").(string),
+		TestTags:       castSetToSliceStrings(d.Get("test_tags").(*schema.Set).List()),
 		StatusCodes:    d.Get("status_codes").(string),
 		UseJar:         d.Get("use_jar").(int),
 		PostRaw:        d.Get("post_raw").(string),
@@ -417,7 +420,7 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 		test.RealBrowser = v.(int)
 	}
 	if v, ok := d.GetOk("test_tags"); ok {
-		test.TestTags = v.(string)
+		test.TestTags = castSetToSliceStrings(v.(*schema.Set).List())
 	}
 	if v, ok := d.GetOk("status_codes"); ok {
 		test.StatusCodes = v.(string)

--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -51,9 +51,11 @@ func resourceStatusCakeTest() *schema.Resource {
 				Required: true,
 			},
 
-			"contact_id": {
-				Type:     schema.TypeInt,
+			"contact_group": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				Set:      schema.HashString,
 			},
 
 			"check_rate": {
@@ -223,7 +225,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		TestType:       d.Get("test_type").(string),
 		Paused:         d.Get("paused").(bool),
 		Timeout:        d.Get("timeout").(int),
-		ContactID:      d.Get("contact_id").(int),
+		ContactGroup:   castSetToSliceStrings(d.Get("contact_group").(*schema.Set).List()),
 		Confirmation:   d.Get("confirmations").(int),
 		Port:           d.Get("port").(int),
 		TriggerRate:    d.Get("trigger_rate").(int),
@@ -312,7 +314,7 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("test_type", testResp.TestType)
 	d.Set("paused", testResp.Paused)
 	d.Set("timeout", testResp.Timeout)
-	d.Set("contact_id", testResp.ContactID)
+	d.Set("contact_group", testResp.ContactGroup)
 	d.Set("confirmations", testResp.Confirmation)
 	d.Set("port", testResp.Port)
 	d.Set("trigger_rate", testResp.TriggerRate)
@@ -356,8 +358,8 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	if v, ok := d.GetOk("check_rate"); ok {
 		test.CheckRate = v.(int)
 	}
-	if v, ok := d.GetOk("contact_id"); ok {
-		test.ContactID = v.(int)
+	if v, ok := d.GetOk("contact_group"); ok {
+		test.ContactGroup = castSetToSliceStrings(v.(*schema.Set).List())
 	}
 	if v, ok := d.GetOk("test_type"); ok {
 		test.TestType = v.(string)

--- a/statuscake/resource_statuscaketest_test.go
+++ b/statuscake/resource_statuscaketest_test.go
@@ -72,7 +72,6 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("statuscake_test.google", "check_rate", "500"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "paused", "true"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "timeout", "40"),
-					resource.TestCheckResourceAttr("statuscake_test.google", "contact_id", "0"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "confirmations", "0"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "trigger_rate", "20"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "custom_header", "{ \"Content-Type\": \"application/x-www-form-urlencoded\" }"),
@@ -159,8 +158,13 @@ func testAccTestCheckAttributes(rn string, test *statuscake.Test) resource.TestC
 				err = check(key, value, strconv.FormatBool(test.Paused))
 			case "timeout":
 				err = check(key, value, strconv.Itoa(test.Timeout))
-			case "contact_id":
-				err = check(key, value, strconv.Itoa(test.ContactID))
+			case "contact_group":
+				for _, tv := range test.ContactGroup {
+					err = check(key, value, tv)
+					if err != nil {
+						return err
+					}
+				}
 			case "confirmations":
 				err = check(key, value, strconv.Itoa(test.Confirmation))
 			case "trigger_rate":
@@ -214,13 +218,10 @@ func testAccTestCheckDestroy(test *statuscake.Test) resource.TestCheckFunc {
 }
 
 func interpolateTerraformTemplate(template string) string {
-	testContactGroupId := 43402
+	testContactGroupId := "43402"
 
 	if v := os.Getenv("STATUSCAKE_TEST_CONTACT_GROUP_ID"); v != "" {
-		id, err := strconv.Atoi(v)
-		if err == nil {
-			testContactGroupId = id
-		}
+		testContactGroupId = v
 	}
 
 	return fmt.Sprintf(template, testContactGroupId)
@@ -233,7 +234,7 @@ resource "statuscake_test" "google" {
 	test_type = "HTTP"
 	check_rate = 300
 	timeout = 10
-	contact_id = %d
+	contact_group = ["%s"]
 	confirmations = 1
 	trigger_rate = 10
 }
@@ -277,7 +278,7 @@ resource "statuscake_test" "google" {
 	test_type = "TCP"
 	check_rate = 300
 	timeout = 10
-	contact_id = %d
+	contact_group = ["%s"]
 	confirmations = 1
 	port = 80
 }

--- a/statuscake/resource_statuscaketest_test.go
+++ b/statuscake/resource_statuscaketest_test.go
@@ -91,7 +91,7 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("statuscake_test.google", "find_string", "string15212"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "do_not_find", "false"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "real_browser", "1"),
-					resource.TestCheckResourceAttr("statuscake_test.google", "test_tags", "string8191"),
+					resource.TestCheckResourceAttr("statuscake_test.google", "test_tags.#", "1"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "status_codes", "string23065"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "use_jar", "1"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "post_raw", "string32096"),
@@ -261,7 +261,7 @@ resource "statuscake_test" "google" {
 	find_string = "string15212"
 	do_not_find = false
 	real_browser = 1
-	test_tags = "string8191"
+	test_tags = ["string8191"]
 	status_codes = "string23065"
 	use_jar = 1
 	post_raw = "string32096"

--- a/vendor/github.com/DreamItGetIT/statuscake/errors.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/errors.go
@@ -34,11 +34,14 @@ func (e ValidationError) Error() string {
 }
 
 type updateError struct {
-	Issues interface{}
+	Issues  interface{}
+	Message string
 }
 
 func (e *updateError) Error() string {
 	var messages []string
+
+	messages = append(messages, e.Message)
 
 	if issues, ok := e.Issues.(map[string]interface{}); ok {
 		for k, v := range issues {
@@ -50,6 +53,9 @@ func (e *updateError) Error() string {
 			m := fmt.Sprint(v)
 			messages = append(messages, m)
 		}
+	} else if issue, ok := e.Issues.(interface{}); ok {
+		m := fmt.Sprint(issue)
+		messages = append(messages, m)
 	}
 
 	return strings.Join(messages, ", ")

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -1,6 +1,7 @@
 package statuscake
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -21,43 +22,55 @@ type deleteResponse struct {
 	Error   string `json:"Error"`
 }
 
+type contactGroupDetailResponse struct {
+	ID    int    `json:"ID"`
+	Name  string `json:"Name"`
+	Email string `json:"Email"`
+}
+
 type detailResponse struct {
-	Method          string   `json:"Method"`
-	TestID          int      `json:"TestID"`
-	TestType        string   `json:"TestType"`
-	Paused          bool     `json:"Paused"`
-	WebsiteName     string   `json:"WebsiteName"`
-	URI             string   `json:"URI"`
-	ContactID       int      `json:"ContactID"`
-	Status          string   `json:"Status"`
-	Uptime          float64  `json:"Uptime"`
-	CustomHeader    string   `json:"CustomHeader"`
-	UserAgent       string   `json:"UserAgent"`
-	CheckRate       int      `json:"CheckRate"`
-	Timeout         int      `json:"Timeout"`
-	LogoImage       string   `json:"LogoImage"`
-	Confirmation    int      `json:"Confirmation,string"`
-	WebsiteHost     string   `json:"WebsiteHost"`
-	NodeLocations   []string `json:"NodeLocations"`
-	FindString      string   `json:"FindString"`
-	DoNotFind       bool     `json:"DoNotFind"`
-	LastTested      string   `json:"LastTested"`
-	NextLocation    string   `json:"NextLocation"`
-	Port            int      `json:"Port"`
-	Processing      bool     `json:"Processing"`
-	ProcessingState string   `json:"ProcessingState"`
-	ProcessingOn    string   `json:"ProcessingOn"`
-	DownTimes       int      `json:"DownTimes,string"`
-	Sensitive       bool     `json:"Sensitive"`
-	TriggerRate     int      `json:"TriggerRate,string"`
-	UseJar          int      `json:"UseJar"`
-	PostRaw         string   `json:"PostRaw"`
-	FinalEndpoint   string   `json:"FinalEndpoint"`
-	FollowRedirect  bool     `json:"FollowRedirect"`
-	StatusCodes     []string `json:"StatusCodes"`
+	Method          string                       `json:"Method"`
+	TestID          int                          `json:"TestID"`
+	TestType        string                       `json:"TestType"`
+	Paused          bool                         `json:"Paused"`
+	WebsiteName     string                       `json:"WebsiteName"`
+	URI             string                       `json:"URI"`
+	ContactID       int                          `json:"ContactID"`
+	ContactGroups   []contactGroupDetailResponse `json:"ContactGroups"`
+	Status          string                       `json:"Status"`
+	Uptime          float64                      `json:"Uptime"`
+	CustomHeader    string                       `json:"CustomHeader"`
+	UserAgent       string                       `json:"UserAgent"`
+	CheckRate       int                          `json:"CheckRate"`
+	Timeout         int                          `json:"Timeout"`
+	LogoImage       string                       `json:"LogoImage"`
+	Confirmation    int                          `json:"Confirmation,string"`
+	WebsiteHost     string                       `json:"WebsiteHost"`
+	NodeLocations   []string                     `json:"NodeLocations"`
+	FindString      string                       `json:"FindString"`
+	DoNotFind       bool                         `json:"DoNotFind"`
+	LastTested      string                       `json:"LastTested"`
+	NextLocation    string                       `json:"NextLocation"`
+	Port            int                          `json:"Port"`
+	Processing      bool                         `json:"Processing"`
+	ProcessingState string                       `json:"ProcessingState"`
+	ProcessingOn    string                       `json:"ProcessingOn"`
+	DownTimes       int                          `json:"DownTimes,string"`
+	Sensitive       bool                         `json:"Sensitive"`
+	TriggerRate     int                          `json:"TriggerRate,string"`
+	UseJar          int                          `json:"UseJar"`
+	PostRaw         string                       `json:"PostRaw"`
+	FinalEndpoint   string                       `json:"FinalEndpoint"`
+	FollowRedirect  bool                         `json:"FollowRedirect"`
+	StatusCodes     []string                     `json:"StatusCodes"`
 }
 
 func (d *detailResponse) test() *Test {
+	contactGroupIds := make([]string, len(d.ContactGroups))
+	for i, v := range d.ContactGroups {
+		contactGroupIds[i] = strconv.Itoa(v.ID)
+	}
+
 	return &Test{
 		TestID:         d.TestID,
 		TestType:       d.TestType,
@@ -67,6 +80,7 @@ func (d *detailResponse) test() *Test {
 		CustomHeader:   d.CustomHeader,
 		UserAgent:      d.UserAgent,
 		ContactID:      d.ContactID,
+		ContactGroup:   contactGroupIds,
 		Status:         d.Status,
 		Uptime:         d.Uptime,
 		CheckRate:      d.CheckRate,

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -12,7 +12,7 @@ const queryStringTag = "querystring"
 
 // Test represents a statuscake Test
 type Test struct {
-	// ThiTestID is an int, use this to get more details about this test. If not provided will insert a new check, else will update
+	// TestID is an int, use this to get more details about this test. If not provided will insert a new check, else will update
 	TestID int `json:"TestID" querystring:"TestID" querystringoptions:"omitempty"`
 
 	// Sent tfalse To Unpause and true To Pause.
@@ -33,8 +33,11 @@ type Test struct {
 	// A Port to use on TCP Tests
 	Port int `json:"Port" querystring:"Port"`
 
-	// Contact group ID - will return int of contact group used else 0
-	ContactID int `json:"ContactID" querystring:"ContactGroup"`
+	// Contact group ID - deprecated in favor of ContactGroup but still provided in the API detail response
+	ContactID int `json:"ContactID"`
+
+	// Contact group IDs - will return list of ints or empty if not provided
+	ContactGroup []string `json:"ContactGroup" querystring:"ContactGroup"`
 
 	// Current status at last test
 	Status string `json:"Status"`
@@ -93,7 +96,7 @@ type Test struct {
 	TriggerRate int `json:"TriggerRate" querystring:"TriggerRate"`
 
 	// Tags should be seperated by a comma - no spacing between tags (this,is,a set,of,tags)
-	TestTags string `json:"TestTags" querystring:"TestTags"`
+	TestTags []string `json:"TestTags" querystring:"TestTags"`
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
@@ -283,7 +286,7 @@ func (tt *tests) Update(t *Test) (*Test, error) {
 	}
 
 	if !ur.Success {
-		return nil, &updateError{Issues: ur.Issues}
+		return nil, &updateError{Issues: ur.Issues, Message: ur.Message}
 	}
 
 	t2 := *t

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"checksumSHA1": "6Fo7YzTT+MDviHOsqg6dNw8WrV4=",
+			"checksumSHA1": "AGuqyTuduSvlOIZ9z0eduvFx3qk=",
 			"path": "github.com/DreamItGetIT/statuscake",
-			"revision": "f69198f958d7326f3c110dd9be1c21abbd8a87a7",
-			"revisionTime": "2018-01-30T22:14:43Z"
+			"revision": "a89107babf68135a67bea923d24e0f4d77b5b3a4",
+			"revisionTime": "2018-07-27T06:02:48Z"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",

--- a/website/docs/r/test.html.markdown
+++ b/website/docs/r/test.html.markdown
@@ -14,11 +14,11 @@ The test resource allows StatusCake tests to be managed by Terraform.
 
 ```hcl
 resource "statuscake_test" "google" {
-  website_name = "google.com"
-  website_url  = "www.google.com"
-  test_type    = "HTTP"
-  check_rate   = 300
-  contact_id   = 12345
+  website_name  = "google.com"
+  website_url   = "www.google.com"
+  test_type     = "HTTP"
+  check_rate    = 300
+  contact_group = ["12345"]
 }
 ```
 
@@ -29,7 +29,7 @@ The following arguments are supported:
 * `website_name` - (Required) This is the name of the test and the website to be monitored.
 * `website_url` - (Required) The URL of the website to be monitored
 * `check_rate` - (Optional) Test check rate in seconds. Defaults to 300
-* `contact_id` - (Optional) The id of the contact group to be add to the test.  Each test can have only one.
+* `contact_group` - (Optional) Set test contact groups, must be array of strings. 
 * `test_type` - (Required) The type of Test. Either HTTP, TCP, PING, or DNS
 * `paused` - (Optional) Whether or not the test is paused. Defaults to false.
 * `timeout` - (Optional) The timeout of the test in seconds.

--- a/website/docs/r/test.html.markdown
+++ b/website/docs/r/test.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `find_string` - (Optional) A string that should either be found or not found.
 * `do_not_find` - (Optional) If the above string should be found to trigger a alert. 1 = will trigger if find_string found.
 * `real_browser` - (Optional) Use 1 to TURN OFF real browser testing.
-* `test_tags` - (Optional) Tags should be seperated by a comma - no spacing between tags (this,is,a set,of,tags).
+* `test_tags` - (Optional) Set test tags, must be array of strings.
 * `status_codes` - (Optional) Comma Seperated List of StatusCodes to Trigger Error on. Defaults are "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599".
 * `use_jar` - (Optional) Set to true to enable the Cookie Jar. Required for some redirects. Default is false.
 * `post_raw` - (Optional) Use to populate the RAW POST data field on the test.


### PR DESCRIPTION
And fix tag handling.

This depends on https://github.com/DreamItGetIT/statuscake/pull/28 which is still unmerged so concidering this WIP for now.

This introduces two breaking changes:

- `contact_id` has been removed, and replaced by `contact_group`, a list of contact IDs
- `test_tags` has been switched from a CSV string to a list of strings

I originally attempted to provide some sort of backward compatibility on `contact_id` but was unable to do it in a way that would avoid perpetual plan changes.

Just realized I have the naming as singular so I'll fix that as well before final review/test/merge