### PR TITLE
Add support back for contact_id and mark it as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 NOTES:
 
-* resource/statuscake_test: `contact_id (int)` has been replaced with `contact_group (type: list)`
+* resource/statuscake_test: `contact_id (int)` has been deprecated, use instead: `contact_group (type: list)`
 * resource:statuscake_test: `test_tags` has been changed from a CSV string to list of strings
 
 

--- a/statuscake/resource_statuscaketest_test.go
+++ b/statuscake/resource_statuscaketest_test.go
@@ -30,6 +30,25 @@ func TestAccStatusCake_basic(t *testing.T) {
 	})
 }
 
+func TestAccStatusCake_basic_deprecated_contact_ID(t *testing.T) {
+	var test statuscake.Test
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccTestCheckDestroy(&test),
+		Steps: []resource.TestStep{
+			{
+				Config: interpolateTerraformTemplate(testAccTestConfig_deprecated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccTestCheckExists("statuscake_test.google", &test),
+					testAccTestCheckAttributes("statuscake_test.google", &test),
+				),
+			},
+		},
+	})
+}
+
 func TestAccStatusCake_tcp(t *testing.T) {
 	var test statuscake.Test
 
@@ -239,7 +258,18 @@ resource "statuscake_test" "google" {
 	trigger_rate = 10
 }
 `
-
+const testAccTestConfig_deprecated = `
+resource "statuscake_test" "google" {
+	website_name = "google.com"
+	website_url = "www.google.com"
+	test_type = "HTTP"
+	check_rate = 300
+	timeout = 10
+	contact_id = %s
+	confirmations = 1
+	trigger_rate = 10
+}
+`
 const testAccTestConfig_update = `
 resource "statuscake_test" "google" {
 	website_name = "google.com"

--- a/website/docs/r/test.html.markdown
+++ b/website/docs/r/test.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 * `website_name` - (Required) This is the name of the test and the website to be monitored.
 * `website_url` - (Required) The URL of the website to be monitored
 * `check_rate` - (Optional) Test check rate in seconds. Defaults to 300
+* `contact_id` - **Deprecated** (Optional) The id of the contact group to be added to the test. Each test can have only one. 
 * `contact_group` - (Optional) Set test contact groups, must be array of strings. 
 * `test_type` - (Required) The type of Test. Either HTTP, TCP, PING, or DNS
 * `paused` - (Optional) Whether or not the test is paused. Defaults to false.
@@ -51,7 +52,7 @@ The following arguments are supported:
 * `do_not_find` - (Optional) If the above string should be found to trigger a alert. 1 = will trigger if find_string found.
 * `real_browser` - (Optional) Use 1 to TURN OFF real browser testing.
 * `test_tags` - (Optional) Set test tags, must be array of strings.
-* `status_codes` - (Optional) Comma Seperated List of StatusCodes to Trigger Error on. Defaults are "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599".
+* `status_codes` - (Optional) Comma Separated List of StatusCodes to Trigger Error on. Defaults are "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599".
 * `use_jar` - (Optional) Set to true to enable the Cookie Jar. Required for some redirects. Default is false.
 * `post_raw` - (Optional) Use to populate the RAW POST data field on the test.
 * `final_endpoint` - (Optional) Use to specify the expected Final URL in the testing process.


### PR DESCRIPTION
This makes the contact_group change backwards compatible